### PR TITLE
Solve issue #12 by adding class filters

### DIFF
--- a/src/main/java/com/blogspot/debukkitsblog/util/FileStorage.java
+++ b/src/main/java/com/blogspot/debukkitsblog/util/FileStorage.java
@@ -1,114 +1,96 @@
 package com.blogspot.debukkitsblog.util;
 
-import java.io.*;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputFilter;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-/**
- * FileStorage provides a mechanism to store and load serializable objects in a
- * file using unique string keys.
- * <p>
- * This class extends {@link HashMap} and supports optional automatic saving on
- * every modification (put/remove) or manual saving via {@link #save()}.
- * <p>
- * For security purposes, only specific classes allowed via
- * {@link #addAllowedClasses(Class[])} can be stored or loaded.
- * 
- * <p>
- * Usage example:
- * 
- * <pre>
- * FileStorage storage = new FileStorage("data.dat", true, new Class[] { MyClass.class });
- * storage.put("key1", myObject);
- * MyClass obj = (MyClass) storage.get("key1");
- * </pre>
- * 
- * @author DeBukkIt
- * @version 1.3.0
- */
 public class FileStorage extends HashMap<String, Object> {
 
+	/**
+	 * 
+	 */
 	private static final long serialVersionUID = -6375762323691191760L;
 
 	private File storageFile;
 	private List<Class<?>> allowedClasses;
+
 	private boolean autosave = true;
 
 	/**
-	 * Creates a FileStorage instance with a specified file path and optional
-	 * automatic saving.
-	 *
-	 * @param filepath       The file path where data will be stored
-	 * @param autosave       If true, the data will be automatically saved after
-	 *                       each {@link #put(String, Object)} operation
-	 * @param allowedClasses Array of classes that are allowed to be stored and
-	 *                       loaded
-	 * @throws IOException              If the file cannot be created or opened
-	 * @throws IllegalArgumentException If the specified file is a directory
-	 * @throws ClassNotFoundException   If an unknown class is encountered when
-	 *                                  loading
+	 * Creates a FileStorage. It allows you to store your serializable object in a
+	 * file using a key for identification and to read it somewhen later.
+	 * 
+	 * @param autosave Whether every <code>store</code> operation shall
+	 *                 automatically write the whole FileStorage to disk. If false,
+	 *                 you will need to call the <code>save</code> method manually.
+	 * @param filepath The path of the file your data shall be stored in
+	 * @throws IOException              if the file cannot be created
+	 * @throws IllegalArgumentException if the file is a directory
+	 * @throws ClassNotFoundException 
 	 */
-	public FileStorage(String filepath, boolean autosave, Class<?>[] allowedClasses)
-			throws IllegalArgumentException, IOException, ClassNotFoundException {
+	public FileStorage(String filepath, boolean autosave, Class<?>[] allowedClasses) throws IllegalArgumentException, IOException, ClassNotFoundException {
 		this(new File(filepath), autosave, allowedClasses);
 	}
 
 	/**
-	 * Creates a FileStorage instance with a specified file path.
-	 * <p>
-	 * All changes will be automatically saved.
-	 *
-	 * @param filepath       The file path where data will be stored
-	 * @param allowedClasses Array of classes that are allowed to be stored and
-	 *                       loaded
-	 * @throws IOException              If the file cannot be created or opened
-	 * @throws IllegalArgumentException If the specified file is a directory
-	 * @throws ClassNotFoundException   If an unknown class is encountered when
-	 *                                  loading
+	 * Creates a FileStorage. It allows you to store your serializable object in a
+	 * file using a key for identification and to read it somewhen later.<br>
+	 * All data <code>store</code>d in this FileStorage will instantly be stored in
+	 * the given file. This might cause many write operations on disk.
+	 * 
+	 * @param file The file your data shall be stored in
+	 * @throws IOException              if your file cannot be created
+	 * @throws IllegalArgumentException if your file is a directory
+	 * @throws ClassNotFoundException 
 	 */
-	public FileStorage(String filepath, Class<?>[] allowedClasses)
-			throws IOException, IllegalArgumentException, ClassNotFoundException {
+	public FileStorage(String filepath, Class<?>[] allowedClasses) throws IOException, IllegalArgumentException, ClassNotFoundException {
 		this(new File(filepath), allowedClasses);
 	}
 
 	/**
-	 * Creates a FileStorage instance with a specified file and optional automatic
-	 * saving.
-	 *
-	 * @param file           The file where data will be stored
-	 * @param autosave       If true, the data will be automatically saved after
-	 *                       each {@link #put(String, Object)} operation
-	 * @param allowedClasses Array of classes that are allowed to be stored and
-	 *                       loaded
-	 * @throws IOException              If the file cannot be created or opened
-	 * @throws IllegalArgumentException If the specified file is a directory
-	 * @throws ClassNotFoundException   If an unknown class is encountered when
-	 *                                  loading
+	 * Creates a FileStorage. It allows you to store your serializable object in a
+	 * file using a key for identification and to read it somewhen later.
+	 * 
+	 * @param autosave Whether every <code>store</code> operation shall
+	 *                 automatically write the whole FileStorage to disk. If false,
+	 *                 you will need to call the <code>save</code> method manually.
+	 * @param file     The file your data shall be stored in
+	 * @throws IOException              if the file cannot be created
+	 * @throws IllegalArgumentException if the file is a directory
+	 * @throws ClassNotFoundException 
 	 */
-	public FileStorage(File file, boolean autosave, Class<?>[] allowedClasses)
-			throws IllegalArgumentException, IOException, ClassNotFoundException {
+	public FileStorage(File file, boolean autosave, Class<?>[] allowedClasses) throws IllegalArgumentException, IOException, ClassNotFoundException {
 		this(file, allowedClasses);
 		this.autosave = autosave;
 	}
 
 	/**
-	 * Creates a FileStorage instance with a specified file.
-	 * <p>
-	 * All changes will be saved automatically unless autosave is disabled.
-	 *
-	 * @param file           The file where data will be stored
-	 * @param allowedClasses Array of classes that are allowed to be stored and
-	 *                       loaded
-	 * @throws IOException              If the file cannot be created or opened
-	 * @throws IllegalArgumentException If the specified file is a directory
-	 * @throws ClassNotFoundException   If an unknown class is encountered when
-	 *                                  loading
+	 * Creates a FileStorage. It allows you to store your serializable object in a
+	 * file using a key for identification and to read it somewhen later.<br>
+	 * All data <code>store</code>d in this FileStorage will be stored in the given
+	 * file. This might cause many write operations on disk. Disable the autosave
+	 * option with the appropriate constructor to prevent this and instead
+	 * <code>save</code> manually at desired times.
+	 * 
+	 * @param file The file your data shall be stored in
+	 * @throws IOException              if your file cannot be created
+	 * @throws IllegalArgumentException if your file is a directory
+	 * @throws ClassNotFoundException 
 	 */
-	public FileStorage(File file, Class<?>[] allowedClasses)
-			throws IOException, IllegalArgumentException, ClassNotFoundException {
+	public FileStorage(File file, Class<?>[] allowedClasses) throws IOException, IllegalArgumentException, ClassNotFoundException {
+		// Enforce canonical file paths for security reasons
 		this.storageFile = file.getCanonicalFile();
 		this.allowedClasses = new ArrayList<>();
+		
 		allowNecessaryClasses();
 		addAllowedClasses(allowedClasses);
 
@@ -122,16 +104,13 @@ public class FileStorage extends HashMap<String, Object> {
 			load();
 		}
 	}
-
+	
 	/**
-	 * Inserts an object associated with a key. If a value already exists under the
-	 * key, it will be overwritten.
-	 * <p>
-	 * If autosave is enabled, the file will be updated immediately after insertion.
-	 *
-	 * @param key   The key under which the object will be stored
-	 * @param value The object to store
-	 * @return The previous value associated with the key, or null if none existed
+	 * Associates the specified value with the specified key in this map.If the map
+	 * previously contained a mapping for the key, the oldvalue is replaced.<br>
+	 * If autosave is enabled (see constructor options), the FileStorage is
+	 * immediately written to the file system after putting; if not, use
+	 * <code>save()</code> to write it manually whenever you want.
 	 */
 	@Override
 	public Object put(String key, Object value) {
@@ -145,14 +124,12 @@ public class FileStorage extends HashMap<String, Object> {
 		}
 		return result;
 	}
-
+	
 	/**
-	 * Removes an object associated with a given key.
-	 * <p>
-	 * If autosave is enabled, the file will be updated immediately after removal.
-	 *
-	 * @param key The key of the object to remove
-	 * @return The removed value, or null if none existed
+	 * Removes the mapping for the specified key from this map if present.
+	 * If autosave is enabled (see constructor options), the FileStorage is
+	 * immediately written to the file system after removing; if not, use
+	 * <code>save()</code> to write it manually whenever you want.
 	 */
 	@Override
 	public Object remove(Object key) {
@@ -163,98 +140,120 @@ public class FileStorage extends HashMap<String, Object> {
 			} catch (IOException e) {
 				onException(e);
 			}
-		}
+		}		
 		return result;
 	}
 
 	/**
-	 * Saves the current contents of this FileStorage to the underlying file.
-	 * <p>
-	 * Only objects of allowed classes will be written to the file. This method can
-	 * throw an {@link IOException} if an I/O error occurs.
-	 *
-	 * @throws IOException If an error occurs while writing to the file
+	 * Stores the FileStorage in the file on disk
 	 */
 	public void save() throws IOException {
-		try (ObjectOutputStream out = new ObjectOutputStream(new FileOutputStream(storageFile))) {
-			out.writeObject(this);
-		}
+		ObjectOutputStream oos = new ObjectOutputStream(new BufferedOutputStream(new FileOutputStream(storageFile)));
+		oos.writeObject(this);
+		oos.flush();
+		oos.close();
 	}
 
 	/**
-	 * Loads the contents of this FileStorage from the underlying file.
-	 * <p>
-	 * Only objects of allowed classes will be loaded. If an object of an unknown
-	 * class is encountered, a {@link ClassNotFoundException} is thrown.
-	 *
-	 * @throws IOException            If an error occurs while reading from the file
-	 * @throws ClassNotFoundException If an object of an unknown class is
-	 *                                encountered
+	 * Loads the FileStorage from the file
+	 * @throws IOException 
+	 * @throws ClassNotFoundException 
 	 */
-	public void load() throws IOException, ClassNotFoundException {
-		try (ObjectInputStream in = new ObjectInputStream(new FileInputStream(storageFile))) {
-			FileStorage loaded = (FileStorage) in.readObject();
+	protected void load() throws IOException, ClassNotFoundException {
+		if(allowedClasses.isEmpty()) {
+			throw new IllegalStateException("No classes whitelisted, cannot load anything from file for security reasons. Use addAllowedClass(...) to whitelist classes.");
+		}
+		try (ObjectInputStream ois = new ObjectInputStream(new BufferedInputStream(new FileInputStream(storageFile)))) {
+			ois.setObjectInputFilter(generateObjectInputFilter());
+			FileStorage fileStorageFromFile = (FileStorage) ois.readObject();
+			ois.close();
+
+			// Clear, then populate the inherited HashMap with objects
 			this.clear();
-			this.putAll(loaded);
-		}
-	}
-
-	/**
-	 * Adds classes to the list of allowed classes that can be stored or loaded.
-	 *
-	 * @param classes Array of classes to allow
-	 */
-	public void addAllowedClasses(Class<?>[] classes) {
-		if (classes != null) {
-			for (Class<?> cls : classes) {
-				if (!allowedClasses.contains(cls)) {
-					allowedClasses.add(cls);
-				}
+			for (String remoteKey : fileStorageFromFile.keySet()) {
+				this.put(remoteKey, fileStorageFromFile.get(remoteKey));
 			}
 		}
 	}
 
 	/**
-	 * Adds classes that are necessary for the FileStorage functionality itself.
-	 * <p>
-	 * This typically includes standard Java classes such as HashMap and ArrayList
-	 * to ensure that the internal structure can be serialized correctly.
+	 * Reads your object from the storage.<br>
+	 * <br>
+	 * Use <u>get(String key, String password)</u> for AES encrypted objects.
+	 * 
+	 * @param key The key the object is available under
+	 * @return your Object or null if nothing was found for <i>key</i>
 	 */
-	private void allowNecessaryClasses() {
-		allowedClasses.add(HashMap.class);
-		allowedClasses.add(ArrayList.class);
+	public Object get(String key) {
+		return super.get(key);
+	}
+	
+	public void addAllowedClasses(Class<?>[] allowedClasses) {
+		for(Class<?> c : allowedClasses) {
+			this.allowedClasses.add(c);
+		}
+	}
+	
+	public void removeAllowedClasses(Class<?>[] allowedClasses) {
+		for(Class<?> c : allowedClasses) {
+			this.allowedClasses.remove(c);
+		}
+	}
+	
+	protected void allowNecessaryClasses() {
+		addAllowedClasses(new Class[] {
+			FileStorage.class,
+			HashMap.class,
+			ArrayList.class,
+			File.class
+		});
+	}
+	
+	protected ObjectInputFilter generateObjectInputFilter() {
+		return (filterInfo) -> {
+			Class<?> serialClass = filterInfo.serialClass();
+			
+			if (serialClass == null) {
+				return ObjectInputFilter.Status.UNDECIDED;
+			}
+
+			if (serialClass.isArray() || serialClass.isPrimitive() || allowedClasses.contains(serialClass)) {
+				return ObjectInputFilter.Status.ALLOWED;
+			}
+			
+			return ObjectInputFilter.Status.REJECTED;
+		};
 	}
 
 	/**
-	 * Handles exceptions that occur during automatic saving.
-	 * <p>
-	 * By default, this method prints the stack trace. Subclasses can override this
-	 * method to provide custom exception handling behavior.
-	 *
-	 * @param e The exception that occurred
+	 * Prints all stored keys with corresponding objects
 	 */
-	protected void onException(Exception e) {
+	public void printAll() {
+		System.out.println(this);
+	}
+
+	/**
+	 * @return a String representation of the HashMap containing all the key-object
+	 *         pairs.
+	 */
+	@Override
+	public String toString() {
+		String result = "FileStorage @ " + storageFile.getAbsolutePath() + "\n";
+		for (String cKey : super.keySet()) {
+			result += cKey + " :: " + super.get(cKey) + "\n";
+		}
+		return result.trim();
+	}
+	
+	/**
+	 * Executed whenever an exception is thrown within this class. By default, the
+	 * printStackTrace() method of the respective exception is executed. Override
+	 * this method to handle exceptions differently.
+	 * 
+	 * @param e The Exception thrown
+	 */
+	public void onException(Exception e) {
 		e.printStackTrace();
 	}
 
-	/**
-	 * Returns whether autosave is enabled.
-	 *
-	 * @return true if autosave is enabled, false otherwise
-	 */
-	public boolean isAutosave() {
-		return autosave;
-	}
-
-	/**
-     * Sets whether autosave is enabled.
-     * <p>
-     * When enabled, changes to this FileStorage are saved automatically to the file.
-     *
-     * @param autosave true to enable autosave, false to disable it
-     */
-    public void setAutosave(boolean autosave) {
-        this.autosave = autosave;
-    }
-    
 }

--- a/src/main/java/com/blogspot/debukkitsblog/util/FileStorage.java
+++ b/src/main/java/com/blogspot/debukkitsblog/util/FileStorage.java
@@ -13,6 +13,28 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
+/**
+ * FileStorage provides a mechanism to store and load serializable objects in a
+ * file using unique string keys.
+ * <p>
+ * This class extends {@link HashMap} and supports optional automatic saving on
+ * every modification (put/remove) or manual saving via {@link #save()}.
+ * <p>
+ * For security purposes, only specific classes allowed via
+ * {@link #addAllowedClasses(Class[])} can be stored or loaded.
+ * 
+ * <p>
+ * Usage example:
+ * 
+ * <pre>
+ * FileStorage storage = new FileStorage("data.dat", true, new Class[] { MyClass.class });
+ * storage.put("key1", myObject);
+ * MyClass obj = (MyClass) storage.get("key1");
+ * </pre>
+ * 
+ * @author DeBukkIt
+ * @version 1.3.0
+ */
 public class FileStorage extends HashMap<String, Object> {
 
 	/**
@@ -26,71 +48,81 @@ public class FileStorage extends HashMap<String, Object> {
 	private boolean autosave = true;
 
 	/**
-	 * Creates a FileStorage. It allows you to store your serializable object in a
-	 * file using a key for identification and to read it somewhen later.
-	 * 
-	 * @param autosave Whether every <code>store</code> operation shall
-	 *                 automatically write the whole FileStorage to disk. If false,
-	 *                 you will need to call the <code>save</code> method manually.
-	 * @param filepath The path of the file your data shall be stored in
-	 * @throws IOException              if the file cannot be created
-	 * @throws IllegalArgumentException if the file is a directory
-	 * @throws ClassNotFoundException 
+	 * Creates a FileStorage instance with a specified file path and optional
+	 * automatic saving.
+	 *
+	 * @param filepath       The file path where data will be stored
+	 * @param autosave       If true, the data will be automatically saved after
+	 *                       each {@link #put(String, Object)} operation
+	 * @param allowedClasses Array of classes that are allowed to be stored and
+	 *                       loaded
+	 * @throws IOException              If the file cannot be created or opened
+	 * @throws IllegalArgumentException If the specified file is a directory
+	 * @throws ClassNotFoundException   If an unknown class is encountered when
+	 *                                  loading
 	 */
-	public FileStorage(String filepath, boolean autosave, Class<?>[] allowedClasses) throws IllegalArgumentException, IOException, ClassNotFoundException {
+	public FileStorage(String filepath, boolean autosave, Class<?>[] allowedClasses)
+			throws IllegalArgumentException, IOException, ClassNotFoundException {
 		this(new File(filepath), autosave, allowedClasses);
 	}
 
 	/**
-	 * Creates a FileStorage. It allows you to store your serializable object in a
-	 * file using a key for identification and to read it somewhen later.<br>
-	 * All data <code>store</code>d in this FileStorage will instantly be stored in
-	 * the given file. This might cause many write operations on disk.
-	 * 
-	 * @param file The file your data shall be stored in
-	 * @throws IOException              if your file cannot be created
-	 * @throws IllegalArgumentException if your file is a directory
-	 * @throws ClassNotFoundException 
+	 * Creates a FileStorage instance with a specified file path.
+	 * <p>
+	 * All changes will be automatically saved.
+	 *
+	 * @param filepath       The file path where data will be stored
+	 * @param allowedClasses Array of classes that are allowed to be stored and
+	 *                       loaded
+	 * @throws IOException              If the file cannot be created or opened
+	 * @throws IllegalArgumentException If the specified file is a directory
+	 * @throws ClassNotFoundException   If an unknown class is encountered when
+	 *                                  loading
 	 */
-	public FileStorage(String filepath, Class<?>[] allowedClasses) throws IOException, IllegalArgumentException, ClassNotFoundException {
+	public FileStorage(String filepath, Class<?>[] allowedClasses)
+			throws IOException, IllegalArgumentException, ClassNotFoundException {
 		this(new File(filepath), allowedClasses);
 	}
 
 	/**
-	 * Creates a FileStorage. It allows you to store your serializable object in a
-	 * file using a key for identification and to read it somewhen later.
-	 * 
-	 * @param autosave Whether every <code>store</code> operation shall
-	 *                 automatically write the whole FileStorage to disk. If false,
-	 *                 you will need to call the <code>save</code> method manually.
-	 * @param file     The file your data shall be stored in
-	 * @throws IOException              if the file cannot be created
-	 * @throws IllegalArgumentException if the file is a directory
-	 * @throws ClassNotFoundException 
+	 * Creates a FileStorage instance with a specified file and optional automatic
+	 * saving.
+	 *
+	 * @param file           The file where data will be stored
+	 * @param autosave       If true, the data will be automatically saved after
+	 *                       each {@link #put(String, Object)} operation
+	 * @param allowedClasses Array of classes that are allowed to be stored and
+	 *                       loaded
+	 * @throws IOException              If the file cannot be created or opened
+	 * @throws IllegalArgumentException If the specified file is a directory
+	 * @throws ClassNotFoundException   If an unknown class is encountered when
+	 *                                  loading
 	 */
-	public FileStorage(File file, boolean autosave, Class<?>[] allowedClasses) throws IllegalArgumentException, IOException, ClassNotFoundException {
+	public FileStorage(File file, boolean autosave, Class<?>[] allowedClasses)
+			throws IllegalArgumentException, IOException, ClassNotFoundException {
 		this(file, allowedClasses);
 		this.autosave = autosave;
 	}
 
 	/**
-	 * Creates a FileStorage. It allows you to store your serializable object in a
-	 * file using a key for identification and to read it somewhen later.<br>
-	 * All data <code>store</code>d in this FileStorage will be stored in the given
-	 * file. This might cause many write operations on disk. Disable the autosave
-	 * option with the appropriate constructor to prevent this and instead
-	 * <code>save</code> manually at desired times.
-	 * 
-	 * @param file The file your data shall be stored in
-	 * @throws IOException              if your file cannot be created
-	 * @throws IllegalArgumentException if your file is a directory
-	 * @throws ClassNotFoundException 
+	 * Creates a FileStorage instance with a specified file.
+	 * <p>
+	 * All changes will be saved automatically unless autosave is disabled.
+	 *
+	 * @param file           The file where data will be stored
+	 * @param allowedClasses Array of classes that are allowed to be stored and
+	 *                       loaded
+	 * @throws IOException              If the file cannot be created or opened
+	 * @throws IllegalArgumentException If the specified file is a directory
+	 * @throws ClassNotFoundException   If an unknown class is encountered when
+	 *                                  loading
 	 */
-	public FileStorage(File file, Class<?>[] allowedClasses) throws IOException, IllegalArgumentException, ClassNotFoundException {
+	public FileStorage(File file, Class<?>[] allowedClasses)
+			throws IOException, IllegalArgumentException, ClassNotFoundException {
 		// Enforce canonical file paths for security reasons
 		this.storageFile = file.getCanonicalFile();
 		this.allowedClasses = new ArrayList<>();
-		
+
 		allowNecessaryClasses();
 		addAllowedClasses(allowedClasses);
 
@@ -104,13 +136,16 @@ public class FileStorage extends HashMap<String, Object> {
 			load();
 		}
 	}
-	
+
 	/**
-	 * Associates the specified value with the specified key in this map.If the map
-	 * previously contained a mapping for the key, the oldvalue is replaced.<br>
-	 * If autosave is enabled (see constructor options), the FileStorage is
-	 * immediately written to the file system after putting; if not, use
-	 * <code>save()</code> to write it manually whenever you want.
+	 * Inserts an object associated with a key. If a value already exists under the
+	 * key, it will be overwritten.
+	 * <p>
+	 * If autosave is enabled, the file will be updated immediately after insertion.
+	 *
+	 * @param key   The key under which the object will be stored
+	 * @param value The object to store
+	 * @return The previous value associated with the key, or null if none existed
 	 */
 	@Override
 	public Object put(String key, Object value) {
@@ -124,12 +159,14 @@ public class FileStorage extends HashMap<String, Object> {
 		}
 		return result;
 	}
-	
+
 	/**
-	 * Removes the mapping for the specified key from this map if present.
-	 * If autosave is enabled (see constructor options), the FileStorage is
-	 * immediately written to the file system after removing; if not, use
-	 * <code>save()</code> to write it manually whenever you want.
+	 * Removes an object associated with a given key.
+	 * <p>
+	 * If autosave is enabled, the file will be updated immediately after removal.
+	 *
+	 * @param key The key of the object to remove
+	 * @return The removed value, or null if none existed
 	 */
 	@Override
 	public Object remove(Object key) {
@@ -140,12 +177,17 @@ public class FileStorage extends HashMap<String, Object> {
 			} catch (IOException e) {
 				onException(e);
 			}
-		}		
+		}
 		return result;
 	}
 
 	/**
-	 * Stores the FileStorage in the file on disk
+	 * Saves the current contents of this FileStorage to the underlying file.
+	 * <p>
+	 * Only objects of allowed classes will be written to the file. This method can
+	 * throw an {@link IOException} if an I/O error occurs.
+	 *
+	 * @throws IOException If an error occurs while writing to the file
 	 */
 	public void save() throws IOException {
 		ObjectOutputStream oos = new ObjectOutputStream(new BufferedOutputStream(new FileOutputStream(storageFile)));
@@ -155,13 +197,19 @@ public class FileStorage extends HashMap<String, Object> {
 	}
 
 	/**
-	 * Loads the FileStorage from the file
-	 * @throws IOException 
-	 * @throws ClassNotFoundException 
+	 * Loads the contents of this FileStorage from the underlying file.
+	 * <p>
+	 * Only objects of allowed classes will be loaded. If an object of an unknown
+	 * class is encountered, a {@link ClassNotFoundException} is thrown.
+	 *
+	 * @throws IOException            If an error occurs while reading from the file
+	 * @throws ClassNotFoundException If an object of an unknown class is
+	 *                                encountered
 	 */
 	protected void load() throws IOException, ClassNotFoundException {
-		if(allowedClasses.isEmpty()) {
-			throw new IllegalStateException("No classes whitelisted, cannot load anything from file for security reasons. Use addAllowedClass(...) to whitelist classes.");
+		if (allowedClasses.isEmpty()) {
+			throw new IllegalStateException(
+					"No classes whitelisted, cannot load anything from file for security reasons. Use addAllowedClass(...) to whitelist classes.");
 		}
 		try (ObjectInputStream ois = new ObjectInputStream(new BufferedInputStream(new FileInputStream(storageFile)))) {
 			ois.setObjectInputFilter(generateObjectInputFilter());
@@ -177,42 +225,49 @@ public class FileStorage extends HashMap<String, Object> {
 	}
 
 	/**
-	 * Reads your object from the storage.<br>
-	 * <br>
-	 * Use <u>get(String key, String password)</u> for AES encrypted objects.
-	 * 
-	 * @param key The key the object is available under
-	 * @return your Object or null if nothing was found for <i>key</i>
+	 * Adds classes to the list of allowed classes that can be stored or loaded.
+	 *
+	 * @param allowedClasses Array of classes to allow
 	 */
-	public Object get(String key) {
-		return super.get(key);
-	}
-	
 	public void addAllowedClasses(Class<?>[] allowedClasses) {
-		for(Class<?> c : allowedClasses) {
+		for (Class<?> c : allowedClasses) {
 			this.allowedClasses.add(c);
 		}
 	}
-	
+
+	/**
+	 * Removes classes from the list of allowed classes that can be stored or
+	 * loaded.
+	 * 
+	 * @param allowedClasses Array of classes to remove
+	 */
 	public void removeAllowedClasses(Class<?>[] allowedClasses) {
-		for(Class<?> c : allowedClasses) {
+		for (Class<?> c : allowedClasses) {
 			this.allowedClasses.remove(c);
 		}
 	}
-	
+
+	/**
+	 * Adds classes that are necessary for the FileStorage functionality itself.
+	 * <p>
+	 * This typically includes standard Java classes such as HashMap and ArrayList
+	 * to ensure that the internal structure can be serialized correctly.
+	 */
 	protected void allowNecessaryClasses() {
-		addAllowedClasses(new Class[] {
-			FileStorage.class,
-			HashMap.class,
-			ArrayList.class,
-			File.class
-		});
+		addAllowedClasses(new Class[] { FileStorage.class, HashMap.class, ArrayList.class, File.class });
 	}
-	
+
+	/**
+	 * Generates an ObjectInputFilter object that rejects all classes that are not
+	 * explicitly allowed
+	 * 
+	 * @return an ObjectInputFilter object that rejects all classes that are not
+	 *         explicitly allowed
+	 */
 	protected ObjectInputFilter generateObjectInputFilter() {
 		return (filterInfo) -> {
 			Class<?> serialClass = filterInfo.serialClass();
-			
+
 			if (serialClass == null) {
 				return ObjectInputFilter.Status.UNDECIDED;
 			}
@@ -220,7 +275,7 @@ public class FileStorage extends HashMap<String, Object> {
 			if (serialClass.isArray() || serialClass.isPrimitive() || allowedClasses.contains(serialClass)) {
 				return ObjectInputFilter.Status.ALLOWED;
 			}
-			
+
 			return ObjectInputFilter.Status.REJECTED;
 		};
 	}
@@ -244,13 +299,14 @@ public class FileStorage extends HashMap<String, Object> {
 		}
 		return result.trim();
 	}
-	
+
 	/**
-	 * Executed whenever an exception is thrown within this class. By default, the
-	 * printStackTrace() method of the respective exception is executed. Override
-	 * this method to handle exceptions differently.
-	 * 
-	 * @param e The Exception thrown
+	 * Handles exceptions that occur during automatic saving.
+	 * <p>
+	 * By default, this method prints the stack trace. Subclasses can override this
+	 * method to provide custom exception handling behavior.
+	 *
+	 * @param e The exception that occurred
 	 */
 	public void onException(Exception e) {
 		e.printStackTrace();

--- a/src/main/java/com/blogspot/debukkitsblog/util/FileStorage.java
+++ b/src/main/java/com/blogspot/debukkitsblog/util/FileStorage.java
@@ -1,96 +1,114 @@
 package com.blogspot.debukkitsblog.util;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.ObjectInputFilter;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
+import java.io.*;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
+/**
+ * FileStorage provides a mechanism to store and load serializable objects in a
+ * file using unique string keys.
+ * <p>
+ * This class extends {@link HashMap} and supports optional automatic saving on
+ * every modification (put/remove) or manual saving via {@link #save()}.
+ * <p>
+ * For security purposes, only specific classes allowed via
+ * {@link #addAllowedClasses(Class[])} can be stored or loaded.
+ * 
+ * <p>
+ * Usage example:
+ * 
+ * <pre>
+ * FileStorage storage = new FileStorage("data.dat", true, new Class[] { MyClass.class });
+ * storage.put("key1", myObject);
+ * MyClass obj = (MyClass) storage.get("key1");
+ * </pre>
+ * 
+ * @author DeBukkIt
+ * @version 1.3.0
+ */
 public class FileStorage extends HashMap<String, Object> {
 
-	/**
-	 * 
-	 */
 	private static final long serialVersionUID = -6375762323691191760L;
 
 	private File storageFile;
 	private List<Class<?>> allowedClasses;
-
 	private boolean autosave = true;
 
 	/**
-	 * Creates a FileStorage. It allows you to store your serializable object in a
-	 * file using a key for identification and to read it somewhen later.
-	 * 
-	 * @param autosave Whether every <code>store</code> operation shall
-	 *                 automatically write the whole FileStorage to disk. If false,
-	 *                 you will need to call the <code>save</code> method manually.
-	 * @param filepath The path of the file your data shall be stored in
-	 * @throws IOException              if the file cannot be created
-	 * @throws IllegalArgumentException if the file is a directory
-	 * @throws ClassNotFoundException 
+	 * Creates a FileStorage instance with a specified file path and optional
+	 * automatic saving.
+	 *
+	 * @param filepath       The file path where data will be stored
+	 * @param autosave       If true, the data will be automatically saved after
+	 *                       each {@link #put(String, Object)} operation
+	 * @param allowedClasses Array of classes that are allowed to be stored and
+	 *                       loaded
+	 * @throws IOException              If the file cannot be created or opened
+	 * @throws IllegalArgumentException If the specified file is a directory
+	 * @throws ClassNotFoundException   If an unknown class is encountered when
+	 *                                  loading
 	 */
-	public FileStorage(String filepath, boolean autosave, Class<?>[] allowedClasses) throws IllegalArgumentException, IOException, ClassNotFoundException {
+	public FileStorage(String filepath, boolean autosave, Class<?>[] allowedClasses)
+			throws IllegalArgumentException, IOException, ClassNotFoundException {
 		this(new File(filepath), autosave, allowedClasses);
 	}
 
 	/**
-	 * Creates a FileStorage. It allows you to store your serializable object in a
-	 * file using a key for identification and to read it somewhen later.<br>
-	 * All data <code>store</code>d in this FileStorage will instantly be stored in
-	 * the given file. This might cause many write operations on disk.
-	 * 
-	 * @param file The file your data shall be stored in
-	 * @throws IOException              if your file cannot be created
-	 * @throws IllegalArgumentException if your file is a directory
-	 * @throws ClassNotFoundException 
+	 * Creates a FileStorage instance with a specified file path.
+	 * <p>
+	 * All changes will be automatically saved.
+	 *
+	 * @param filepath       The file path where data will be stored
+	 * @param allowedClasses Array of classes that are allowed to be stored and
+	 *                       loaded
+	 * @throws IOException              If the file cannot be created or opened
+	 * @throws IllegalArgumentException If the specified file is a directory
+	 * @throws ClassNotFoundException   If an unknown class is encountered when
+	 *                                  loading
 	 */
-	public FileStorage(String filepath, Class<?>[] allowedClasses) throws IOException, IllegalArgumentException, ClassNotFoundException {
+	public FileStorage(String filepath, Class<?>[] allowedClasses)
+			throws IOException, IllegalArgumentException, ClassNotFoundException {
 		this(new File(filepath), allowedClasses);
 	}
 
 	/**
-	 * Creates a FileStorage. It allows you to store your serializable object in a
-	 * file using a key for identification and to read it somewhen later.
-	 * 
-	 * @param autosave Whether every <code>store</code> operation shall
-	 *                 automatically write the whole FileStorage to disk. If false,
-	 *                 you will need to call the <code>save</code> method manually.
-	 * @param file     The file your data shall be stored in
-	 * @throws IOException              if the file cannot be created
-	 * @throws IllegalArgumentException if the file is a directory
-	 * @throws ClassNotFoundException 
+	 * Creates a FileStorage instance with a specified file and optional automatic
+	 * saving.
+	 *
+	 * @param file           The file where data will be stored
+	 * @param autosave       If true, the data will be automatically saved after
+	 *                       each {@link #put(String, Object)} operation
+	 * @param allowedClasses Array of classes that are allowed to be stored and
+	 *                       loaded
+	 * @throws IOException              If the file cannot be created or opened
+	 * @throws IllegalArgumentException If the specified file is a directory
+	 * @throws ClassNotFoundException   If an unknown class is encountered when
+	 *                                  loading
 	 */
-	public FileStorage(File file, boolean autosave, Class<?>[] allowedClasses) throws IllegalArgumentException, IOException, ClassNotFoundException {
+	public FileStorage(File file, boolean autosave, Class<?>[] allowedClasses)
+			throws IllegalArgumentException, IOException, ClassNotFoundException {
 		this(file, allowedClasses);
 		this.autosave = autosave;
 	}
 
 	/**
-	 * Creates a FileStorage. It allows you to store your serializable object in a
-	 * file using a key for identification and to read it somewhen later.<br>
-	 * All data <code>store</code>d in this FileStorage will be stored in the given
-	 * file. This might cause many write operations on disk. Disable the autosave
-	 * option with the appropriate constructor to prevent this and instead
-	 * <code>save</code> manually at desired times.
-	 * 
-	 * @param file The file your data shall be stored in
-	 * @throws IOException              if your file cannot be created
-	 * @throws IllegalArgumentException if your file is a directory
-	 * @throws ClassNotFoundException 
+	 * Creates a FileStorage instance with a specified file.
+	 * <p>
+	 * All changes will be saved automatically unless autosave is disabled.
+	 *
+	 * @param file           The file where data will be stored
+	 * @param allowedClasses Array of classes that are allowed to be stored and
+	 *                       loaded
+	 * @throws IOException              If the file cannot be created or opened
+	 * @throws IllegalArgumentException If the specified file is a directory
+	 * @throws ClassNotFoundException   If an unknown class is encountered when
+	 *                                  loading
 	 */
-	public FileStorage(File file, Class<?>[] allowedClasses) throws IOException, IllegalArgumentException, ClassNotFoundException {
-		// Enforce canonical file paths for security reasons
+	public FileStorage(File file, Class<?>[] allowedClasses)
+			throws IOException, IllegalArgumentException, ClassNotFoundException {
 		this.storageFile = file.getCanonicalFile();
 		this.allowedClasses = new ArrayList<>();
-		
 		allowNecessaryClasses();
 		addAllowedClasses(allowedClasses);
 
@@ -104,13 +122,16 @@ public class FileStorage extends HashMap<String, Object> {
 			load();
 		}
 	}
-	
+
 	/**
-	 * Associates the specified value with the specified key in this map.If the map
-	 * previously contained a mapping for the key, the oldvalue is replaced.<br>
-	 * If autosave is enabled (see constructor options), the FileStorage is
-	 * immediately written to the file system after putting; if not, use
-	 * <code>save()</code> to write it manually whenever you want.
+	 * Inserts an object associated with a key. If a value already exists under the
+	 * key, it will be overwritten.
+	 * <p>
+	 * If autosave is enabled, the file will be updated immediately after insertion.
+	 *
+	 * @param key   The key under which the object will be stored
+	 * @param value The object to store
+	 * @return The previous value associated with the key, or null if none existed
 	 */
 	@Override
 	public Object put(String key, Object value) {
@@ -124,12 +145,14 @@ public class FileStorage extends HashMap<String, Object> {
 		}
 		return result;
 	}
-	
+
 	/**
-	 * Removes the mapping for the specified key from this map if present.
-	 * If autosave is enabled (see constructor options), the FileStorage is
-	 * immediately written to the file system after removing; if not, use
-	 * <code>save()</code> to write it manually whenever you want.
+	 * Removes an object associated with a given key.
+	 * <p>
+	 * If autosave is enabled, the file will be updated immediately after removal.
+	 *
+	 * @param key The key of the object to remove
+	 * @return The removed value, or null if none existed
 	 */
 	@Override
 	public Object remove(Object key) {
@@ -140,120 +163,98 @@ public class FileStorage extends HashMap<String, Object> {
 			} catch (IOException e) {
 				onException(e);
 			}
-		}		
+		}
 		return result;
 	}
 
 	/**
-	 * Stores the FileStorage in the file on disk
+	 * Saves the current contents of this FileStorage to the underlying file.
+	 * <p>
+	 * Only objects of allowed classes will be written to the file. This method can
+	 * throw an {@link IOException} if an I/O error occurs.
+	 *
+	 * @throws IOException If an error occurs while writing to the file
 	 */
 	public void save() throws IOException {
-		ObjectOutputStream oos = new ObjectOutputStream(new BufferedOutputStream(new FileOutputStream(storageFile)));
-		oos.writeObject(this);
-		oos.flush();
-		oos.close();
+		try (ObjectOutputStream out = new ObjectOutputStream(new FileOutputStream(storageFile))) {
+			out.writeObject(this);
+		}
 	}
 
 	/**
-	 * Loads the FileStorage from the file
-	 * @throws IOException 
-	 * @throws ClassNotFoundException 
+	 * Loads the contents of this FileStorage from the underlying file.
+	 * <p>
+	 * Only objects of allowed classes will be loaded. If an object of an unknown
+	 * class is encountered, a {@link ClassNotFoundException} is thrown.
+	 *
+	 * @throws IOException            If an error occurs while reading from the file
+	 * @throws ClassNotFoundException If an object of an unknown class is
+	 *                                encountered
 	 */
-	protected void load() throws IOException, ClassNotFoundException {
-		if(allowedClasses.isEmpty()) {
-			throw new IllegalStateException("No classes whitelisted, cannot load anything from file for security reasons. Use addAllowedClass(...) to whitelist classes.");
-		}
-		try (ObjectInputStream ois = new ObjectInputStream(new BufferedInputStream(new FileInputStream(storageFile)))) {
-			ois.setObjectInputFilter(generateObjectInputFilter());
-			FileStorage fileStorageFromFile = (FileStorage) ois.readObject();
-			ois.close();
-
-			// Clear, then populate the inherited HashMap with objects
+	public void load() throws IOException, ClassNotFoundException {
+		try (ObjectInputStream in = new ObjectInputStream(new FileInputStream(storageFile))) {
+			FileStorage loaded = (FileStorage) in.readObject();
 			this.clear();
-			for (String remoteKey : fileStorageFromFile.keySet()) {
-				this.put(remoteKey, fileStorageFromFile.get(remoteKey));
+			this.putAll(loaded);
+		}
+	}
+
+	/**
+	 * Adds classes to the list of allowed classes that can be stored or loaded.
+	 *
+	 * @param classes Array of classes to allow
+	 */
+	public void addAllowedClasses(Class<?>[] classes) {
+		if (classes != null) {
+			for (Class<?> cls : classes) {
+				if (!allowedClasses.contains(cls)) {
+					allowedClasses.add(cls);
+				}
 			}
 		}
 	}
 
 	/**
-	 * Reads your object from the storage.<br>
-	 * <br>
-	 * Use <u>get(String key, String password)</u> for AES encrypted objects.
-	 * 
-	 * @param key The key the object is available under
-	 * @return your Object or null if nothing was found for <i>key</i>
+	 * Adds classes that are necessary for the FileStorage functionality itself.
+	 * <p>
+	 * This typically includes standard Java classes such as HashMap and ArrayList
+	 * to ensure that the internal structure can be serialized correctly.
 	 */
-	public Object get(String key) {
-		return super.get(key);
-	}
-	
-	public void addAllowedClasses(Class<?>[] allowedClasses) {
-		for(Class<?> c : allowedClasses) {
-			this.allowedClasses.add(c);
-		}
-	}
-	
-	public void removeAllowedClasses(Class<?>[] allowedClasses) {
-		for(Class<?> c : allowedClasses) {
-			this.allowedClasses.remove(c);
-		}
-	}
-	
-	protected void allowNecessaryClasses() {
-		addAllowedClasses(new Class[] {
-			FileStorage.class,
-			HashMap.class,
-			ArrayList.class,
-			File.class
-		});
-	}
-	
-	protected ObjectInputFilter generateObjectInputFilter() {
-		return (filterInfo) -> {
-			Class<?> serialClass = filterInfo.serialClass();
-			
-			if (serialClass == null) {
-				return ObjectInputFilter.Status.UNDECIDED;
-			}
-
-			if (serialClass.isArray() || serialClass.isPrimitive() || allowedClasses.contains(serialClass)) {
-				return ObjectInputFilter.Status.ALLOWED;
-			}
-			
-			return ObjectInputFilter.Status.REJECTED;
-		};
+	private void allowNecessaryClasses() {
+		allowedClasses.add(HashMap.class);
+		allowedClasses.add(ArrayList.class);
 	}
 
 	/**
-	 * Prints all stored keys with corresponding objects
+	 * Handles exceptions that occur during automatic saving.
+	 * <p>
+	 * By default, this method prints the stack trace. Subclasses can override this
+	 * method to provide custom exception handling behavior.
+	 *
+	 * @param e The exception that occurred
 	 */
-	public void printAll() {
-		System.out.println(this);
-	}
-
-	/**
-	 * @return a String representation of the HashMap containing all the key-object
-	 *         pairs.
-	 */
-	@Override
-	public String toString() {
-		String result = "FileStorage @ " + storageFile.getAbsolutePath() + "\n";
-		for (String cKey : super.keySet()) {
-			result += cKey + " :: " + super.get(cKey) + "\n";
-		}
-		return result.trim();
-	}
-	
-	/**
-	 * Executed whenever an exception is thrown within this class. By default, the
-	 * printStackTrace() method of the respective exception is executed. Override
-	 * this method to handle exceptions differently.
-	 * 
-	 * @param e The Exception thrown
-	 */
-	public void onException(Exception e) {
+	protected void onException(Exception e) {
 		e.printStackTrace();
 	}
 
+	/**
+	 * Returns whether autosave is enabled.
+	 *
+	 * @return true if autosave is enabled, false otherwise
+	 */
+	public boolean isAutosave() {
+		return autosave;
+	}
+
+	/**
+     * Sets whether autosave is enabled.
+     * <p>
+     * When enabled, changes to this FileStorage are saved automatically to the file.
+     *
+     * @param autosave true to enable autosave, false to disable it
+     */
+    public void setAutosave(boolean autosave) {
+        this.autosave = autosave;
+    }
+    
 }

--- a/src/test/java/TestFileStorage.java
+++ b/src/test/java/TestFileStorage.java
@@ -10,6 +10,7 @@ import java.util.UUID;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.blogspot.debukkitsblog.util.FileStorage;
@@ -23,8 +24,12 @@ class TestFileStorage {
 	
 	@BeforeAll
 	static void prepareTests() {
-		testFile.delete();
 		testObject1 = UUID.randomUUID();
+	}
+	
+	@BeforeEach
+	void removeFileBeforeEachTest() {
+		testFile.delete();
 	}
 	
 	@Test
@@ -42,15 +47,41 @@ class TestFileStorage {
 		}
 		
 	}
-	
+
 	@Test
-	void testB_Remove() {
+	void testB_Read() {
 		
 		try {
 			FileStorage fs = new FileStorage(testFile, new Class[] { String.class, UUID.class } );
-			fs.remove((Object) "TestKey1");
+			fs.put("TestKey1", testString1);
+			fs.put("TestKey2", testObject1);
 			
-			FileStorage fs2 = new FileStorage(testFile, new Class[] { String.class, UUID.class } );
+			Object o1 = fs.get("TestKey1");
+			Object o2 = fs.get("TestKey2");
+			
+			String stringRead = (String) o1;
+			UUID uuidRead = (UUID) o2;
+			
+			assertEquals(testString1, stringRead);
+			assertEquals(testObject1.toString(), uuidRead.toString());
+			
+			return; // passed
+			
+		} catch (IllegalArgumentException | IOException | ClassNotFoundException e) {
+			fail(e);
+		}		
+		
+	}
+	
+	@Test
+	void testC_Remove() {
+		
+		try {
+			FileStorage fs = new FileStorage(testFile, new Class[] { String.class } );
+			fs.put("TestKey1", testString1);
+			fs.remove("TestKey1");
+			
+			FileStorage fs2 = new FileStorage(testFile, new Class[] { String.class } );
 			assertNull(fs2.get("TestKey1"));
 
 			return; // passed
@@ -62,29 +93,16 @@ class TestFileStorage {
 	}
 
 	@Test
-	void testC_Read() {
-		
-		try {
-			FileStorage fs = new FileStorage(testFile, new Class[] { String.class, UUID.class } );
-			Object o1 = fs.get("TestKey1");
-			Object o2 = fs.get("TestKey2");
-			
-			UUID uuidRead = (UUID) o2;
-			
-			assertNull(o1);
-			assertEquals(testObject1.toString(), uuidRead.toString());
-			
-			return; // passed
-			
-		} catch (IllegalArgumentException | IOException | ClassNotFoundException e) {
-			fail(e);
-		}		
-		
-	}
-
-	@Test
 	void testD_ReadNonWhitelistedObject() {
-		assertThrows(InvalidClassException.class, () ->	new FileStorage(testFile, new Class[] { String.class }));				
+		try {
+			FileStorage fs3 = new FileStorage(testFile, new Class[] { String.class });
+			fs3.put("TestKey2", testObject1);
+			
+			assertThrows(InvalidClassException.class, () -> new FileStorage(testFile, new Class[] { String.class }));
+			
+		} catch (IllegalArgumentException | ClassNotFoundException | IOException e) {
+			fail(e);
+		}				
 	}
 	
 	@AfterAll

--- a/src/test/java/TestFileStorage.java
+++ b/src/test/java/TestFileStorage.java
@@ -1,9 +1,11 @@
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InvalidClassException;
 import java.util.UUID;
 
 import org.junit.jupiter.api.AfterAll;
@@ -21,6 +23,7 @@ class TestFileStorage {
 	
 	@BeforeAll
 	static void prepareTests() {
+		testFile.delete();
 		testObject1 = UUID.randomUUID();
 	}
 	
@@ -28,13 +31,13 @@ class TestFileStorage {
 	void testA_Write() {
 		
 		try {
-			FileStorage fs = new FileStorage(testFile);
+			FileStorage fs = new FileStorage(testFile, new Class[] { String.class, UUID.class } );
 			fs.put("TestKey1", testString1);
 			fs.put("TestKey2", testObject1);
 
 			return; // passed
 			
-		} catch (IllegalArgumentException | IOException e) {
+		} catch (IllegalArgumentException | IOException | ClassNotFoundException e) {
 			fail(e);
 		}
 		
@@ -44,15 +47,15 @@ class TestFileStorage {
 	void testB_Remove() {
 		
 		try {
-			FileStorage fs = new FileStorage(testFile);
+			FileStorage fs = new FileStorage(testFile, new Class[] { String.class, UUID.class } );
 			fs.remove((Object) "TestKey1");
 			
-			FileStorage fs2 = new FileStorage(testFile);
+			FileStorage fs2 = new FileStorage(testFile, new Class[] { String.class, UUID.class } );
 			assertNull(fs2.get("TestKey1"));
 
 			return; // passed
 			
-		} catch (IllegalArgumentException | IOException e) {
+		} catch (IllegalArgumentException | IOException | ClassNotFoundException e) {
 			fail(e);
 		}
 		
@@ -62,7 +65,7 @@ class TestFileStorage {
 	void testC_Read() {
 		
 		try {
-			FileStorage fs = new FileStorage(testFile);
+			FileStorage fs = new FileStorage(testFile, new Class[] { String.class, UUID.class } );
 			Object o1 = fs.get("TestKey1");
 			Object o2 = fs.get("TestKey2");
 			
@@ -73,10 +76,15 @@ class TestFileStorage {
 			
 			return; // passed
 			
-		} catch (IllegalArgumentException | IOException e) {
+		} catch (IllegalArgumentException | IOException | ClassNotFoundException e) {
 			fail(e);
 		}		
 		
+	}
+
+	@Test
+	void testD_ReadNonWhitelistedObject() {
+		assertThrows(InvalidClassException.class, () ->	new FileStorage(testFile, new Class[] { String.class }));				
 	}
 	
 	@AfterAll


### PR DESCRIPTION
- Added class filters to prevent `ObjectInputStream` from loading malicious classes (addressing issue #12)
- Removed deprecated methods
- Removed superfluous method `get()` (provided by superclass already)
- Updated and fixed unit tests
- Updated JavaDoc